### PR TITLE
Fix documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ fn main() {
 
 ## Development
 
-This project follows specific development guidelines. Please refer to the UPDATERULES.md file for more information.
+This project follows specific development guidelines. Please refer to the docs/UPDATE_RULES.md file for more information.
 
 ### Running Tests
 

--- a/docs/UPDATE_RULES.md
+++ b/docs/UPDATE_RULES.md
@@ -1,4 +1,4 @@
-# Development Rules for hiredavidparker
+# Development Rules for hire-david-parker
 
 ## Workflow
 


### PR DESCRIPTION
## Summary
- Update development rules document name to use hyphens instead of running words
- Fix README reference to point to the correct location of UPDATE_RULES.md in docs/ directory

## Test plan
- Verify links and references work correctly